### PR TITLE
Add postversion script for 'yarn version'

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "UBDI",
   "license": "MIT",
   "repository": "git://github.com/ubdi/ubdi-cli.git",
+  "scripts": {
+    "postversion": "git push --tags && npm publish && echo \"Successfully released version $npm_package_version!\""
+  },
   "dependencies": {
     "axios": "^0.19.0",
     "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": "git://github.com/ubdi/ubdi-cli.git",
   "scripts": {
-    "postversion": "git push --tags && npm publish && echo \"Successfully released version $npm_package_version!\""
+    "postversion": "git push origin $npm_package_version && npm publish && echo \"Successfully released version $npm_package_version!\""
   },
   "dependencies": {
     "axios": "^0.19.0",


### PR DESCRIPTION
UBDI CLI can be published by using `yarn version` which:
- prompts new version (eg `1.0.6`)
- creates new tag from version name (eg `v1.0.6`)
- executes postversion script which pushes the created tag and executes `npm publish`